### PR TITLE
fix: Toolbar dropdown position

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2144,7 +2144,7 @@ gulp.task(
 );
 
 function packageJson() {
-  const VERSION = "5.0.47";
+  const VERSION = "5.0.48";
 
   const DIST_NAME = "@commutatus/pdfjs-dist";
   const DIST_DESCRIPTION = "Experimental build of Mozilla's PDF.js library.";

--- a/src/display/editor/toolbar.js
+++ b/src/display/editor/toolbar.js
@@ -32,11 +32,6 @@ class EditorToolbar {
     const position = this.#editor.toolbarPosition;
     const { style } = editToolbar;
     if (position) {
-      const x =
-        this.#editor._uiManager.direction === "ltr"
-          ? 1 - position[0]
-          : position[0];
-      style.insetInlineEnd = `${100 * x}%`;
       style.top = `calc(${
         100 * position[1]
       }% + var(--editor-toolbar-vert-offset))`;


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
- When selecting some text the toolbar gets cut under the screen and fixed by removing the `insetInlineEnd` style.

